### PR TITLE
Remove needless parenthesis

### DIFF
--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -62,7 +62,7 @@
                      ((listp (car arg)) arg)
                      ((string-match "^:" (symbol-name (car arg))) (cons name-symbol arg))
                      ((symbolp (car arg)) args)
-                     ((t nil))))
+                     (t nil)))
       (_ nil))))
 
 (defun use-package-handler/:quelpa (name-symbol keyword args rest state)

--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -61,8 +61,7 @@
       ((pred listp) (cond
                      ((listp (car arg)) arg)
                      ((string-match "^:" (symbol-name (car arg))) (cons name-symbol arg))
-                     ((symbolp (car arg)) args)
-                     (t nil)))
+                     ((symbolp (car arg)) args)))
       (_ nil))))
 
 (defun use-package-handler/:quelpa (name-symbol keyword args rest state)


### PR DESCRIPTION
I got following byte-compile warning.

```
In use-package-normalize/:quelpa:
quelpa-use-package.el:63:43:Warning: `t' called as a function

In end of data:
quelpa-use-package.el:109:1:Warning: the function `t' is not known to be
    defined.
```
