### PR TITLE
Don't load quelpa until required.

### DIFF
--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -37,9 +37,9 @@
 
 ;;; Code:
 
-(require 'cl-lib)
-(require 'quelpa)
-(require 'use-package)
+(eval-when-compile
+  (require 'cl-lib)
+  (require 'use-package))
 
 (defvar quelpa-use-package-keyword :quelpa)
 


### PR DESCRIPTION
Current, the quelpa package is loaded when quelpa-use-package is loaded. However, it does not need to actually be loaded until the first call to `quelpa`. Since `quelpa` is autoloaded from the quelpa package on which quelpa-use-package requires, it will be required in on demand when needed.

This allows me to write declarations like this:

```
(use-package something
  :if (not (package-installed-p 'something))
  :quelpa (something ...))
```

The benefit here is that when all the quelpa packages in my config are already installed, quelpa won't be loaded at all on init because `quelpa` is never actually called. This reduced my typical init time by ~20% but still allows me to have quelpa packages on init if they aren't around.
