### PR TITLE
Load quelpa lazily if the user sets an option

### DIFF
--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -37,7 +37,14 @@
 
 ;;; Code:
 
+(defvar quelpa-use-package-inhibit-loading-quelpa nil
+  "If non-nil, `quelpa-use-package' will do its best to avoid
+loading `quelpa' unless necessary. This improves performance, but
+can prevent packages from being updated automatically.")
+
 (require 'cl-lib)
+(unless quelpa-use-package-inhibit-loading-quelpa
+  (require 'quelpa))
 (require 'use-package)
 
 (defvar quelpa-use-package-keyword :quelpa)
@@ -69,7 +76,8 @@
     ;; compiled or evaluated.
     (if args
         (use-package-concat
-         `((unless (package-installed-p ',name-symbol)
+         `((unless (and quelpa-use-package-inhibit-loading-quelpa
+                        (package-installed-p ',name-symbol))
              (apply 'quelpa ',args)))
          body)
       body)))

--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -69,7 +69,8 @@
     ;; compiled or evaluated.
     (if args
         (use-package-concat
-         `((apply 'quelpa ',args))
+         `((unless (package-installed-p ',name-symbol)
+             (apply 'quelpa ',args)))
          body)
       body)))
 

--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -38,7 +38,6 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'quelpa)
 (require 'use-package)
 
 (defvar quelpa-use-package-keyword :quelpa)


### PR DESCRIPTION
This maintains the default behavior, where quelpa is loaded eagerly,
by default. But if the user doesn't like that, then they can set
`quelpa-use-package-inhibit-loading-quelpa`. How does that sound?