### PR TITLE
some updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ If you are using [use-package](https://github.com/jwiegley/use-package) (which c
 
 ## Installation
 
-**Requirements**: Emacs 24.3
+**Requirements**: Emacs 25.1
 
 Assuming you have bootstrapped `quelpa`, install `quelpa-use-package` (which installs `use-package` as a dependency) and require the library:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <a href="https://github.com/quelpa/quelpa"><img align="right" src="https://github.com/quelpa/quelpa/raw/master/logo/quelpa-logo-h64.png"></a>
 # quelpa-use-package
 
+[![MELPA](https://melpa.org/packages/quelpa-use-package-badge.svg)](https://melpa.org/#/quelpa-use-package)
+
 If you are using [use-package](https://github.com/jwiegley/use-package) (which can help to simplify your .emacs) you can use the [quelpa](https://github.com/quelpa/quelpa) handler provided by `quelpa-use-package`.
 
 ## Installation

--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -5,7 +5,7 @@
 ;; Author: steckerhalter
 ;; URL: https://github.com/quelpa/quelpa-use-package
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "24.3") (quelpa "0") (use-package "2"))
+;; Package-Requires: ((emacs "25.1") (quelpa "0") (use-package "2"))
 ;; Keywords: package management elpa use-package
 
 ;; This file is not part of GNU Emacs.
@@ -33,7 +33,7 @@
 
 ;;; Requirements:
 
-;; Emacs 24.3, `quelpa' and `use-package'
+;; Emacs 25.1, `quelpa' and `use-package'
 
 ;;; Code:
 
@@ -90,24 +90,16 @@ can prevent packages from being updated automatically.")
                   ensure)))
     (funcall func name-symbol keyword ensure rest state)))
 
-(defadvice use-package-handler/:ensure (before quelpa-use-package/:ensure)
-  (when (plist-member rest :quelpa)
-    (ad-set-arg 2 nil)))
-
 (defun quelpa-use-package-activate-advice ()
-  (if (version< emacs-version "24.4")
-      (ad-activate 'use-package-handler/:ensure t)
-    (advice-add
-     'use-package-handler/:ensure
-     :around
-     'quelpa-use-package-override-:ensure)))
+  (advice-add
+   'use-package-handler/:ensure
+   :around
+   #'quelpa-use-package-override-:ensure))
 
 (defun quelpa-use-package-deactivate-advice ()
-  (if (version< emacs-version "24.4")
-      (ad-deactivate 'use-package-handler/:ensure)
-    (advice-remove
-     'use-package-handler/:ensure
-     'quelpa-use-package-override-:ensure)))
+  (advice-remove
+   'use-package-handler/:ensure
+   #'quelpa-use-package-override-:ensure))
 
 ;; register keyword on require
 (quelpa-use-package-set-keyword)

--- a/quelpa-use-package.el
+++ b/quelpa-use-package.el
@@ -3,7 +3,7 @@
 ;; Copyright 2015, Steckerhalter
 
 ;; Author: steckerhalter
-;; URL: https://framagit.org/steckerhalter/quelpa-use-package
+;; URL: https://github.com/quelpa/quelpa-use-package
 ;; Version: 0.0.1
 ;; Package-Requires: ((emacs "24.3") (quelpa "0") (use-package "2"))
 ;; Keywords: package management elpa use-package
@@ -29,7 +29,7 @@
 
 ;; quelpa handler for `use-package'
 ;; See the the repo website for more info:
-;; https://framagit.org/steckerhalter/quelpa-use-package
+;; https://github.com/quelpa/quelpa-use-package
 
 ;;; Requirements:
 


### PR DESCRIPTION
I usually use `quelpa` via `quelpa-use-package` and I did some updates for `quelpa-use-package`!

* update framagit.org url to github.com
* bump required emacs version to 25.1 and remove legacy compat code
* add MELPA badge to README.md
